### PR TITLE
First principles datasets

### DIFF
--- a/datasets/first_principles_absorption/first_principles_absorption.tsv.gz
+++ b/datasets/first_principles_absorption/first_principles_absorption.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:469d734ef8b6f79d2e38bc487251940bcaa9349050cb455063209e3371dcd439
+size 158

--- a/datasets/first_principles_bode/first_principles_bode.tsv.gz
+++ b/datasets/first_principles_bode/first_principles_bode.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a568223ad5181bf644ca9e871fd235d0e614895b995155b0cb2dfec53f8f9328
+size 110

--- a/datasets/first_principles_hubble/first_principles_hubble.tsv.gz
+++ b/datasets/first_principles_hubble/first_principles_hubble.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bef7e5fb62eb611f1d60e8418df7b546c0df0ae28a51b5c3f7501b2128fdbb17
+size 674

--- a/datasets/first_principles_ideal_gas/first_principles_ideal_gas.tsv.gz
+++ b/datasets/first_principles_ideal_gas/first_principles_ideal_gas.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eaf8e6160d9629cc73d8b5fccf5a25fdfae617a5c5e6d6e2c00f73d94bc6ab8
+size 1226

--- a/datasets/first_principles_kepler/first_principles_kepler.tsv.gz
+++ b/datasets/first_principles_kepler/first_principles_kepler.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5704b631ba0afc6bf761196ae757565c6ea8398019094526f16383802b8f6cda
+size 118

--- a/datasets/first_principles_leavitt/first_principles_leavitt.tsv.gz
+++ b/datasets/first_principles_leavitt/first_principles_leavitt.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85b0d6a23ccc3a1db5e2a94928c32e35dd2388d2cb13328c9a914fc594e7bab1
+size 526

--- a/datasets/first_principles_newton/first_principles_newton.tsv.gz
+++ b/datasets/first_principles_newton/first_principles_newton.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59df1d16cb8aa383900dc43a067ca79437912283dd3b32e4834b20185efc586e
+size 1291

--- a/datasets/first_principles_planck/first_principles_planck.tsv.gz
+++ b/datasets/first_principles_planck/first_principles_planck.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a70e4196c6288b9132c1fa2515235a18be44b16f6a54fdb04ea043b8027b6ea0
+size 2979

--- a/datasets/first_principles_rydberg/first_principles_rydberg.tsv.gz
+++ b/datasets/first_principles_rydberg/first_principles_rydberg.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4d23f6bf28053df7f91fba6b92e45cd23ce4e37ec96bc0461fd24b38739e9e5
+size 564

--- a/datasets/first_principles_schechter/first_principles_schechter.tsv.gz
+++ b/datasets/first_principles_schechter/first_principles_schechter.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f2719ff31476c7e53e05dd4f85fa2a53d165e5adc8d80a3ab8415474ffe232a
+size 599

--- a/datasets/first_principles_supernovae_zg/first_principles_supernovae_zg.tsv.gz
+++ b/datasets/first_principles_supernovae_zg/first_principles_supernovae_zg.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcaa3bfa39bf7786ccc074e5fc44d2f6e3870562c505d08fec8859cc5d51af05
+size 4109

--- a/datasets/first_principles_supernovae_zr/first_principles_supernovae_zr.tsv.gz
+++ b/datasets/first_principles_supernovae_zr/first_principles_supernovae_zr.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5910dd1ee08ef353c08e2c25b629f66d42565eb4c990656e06d1b575fe5880a7
+size 3923

--- a/datasets/first_principles_tully_fisher/first_principles_tully_fisher.tsv.gz
+++ b/datasets/first_principles_tully_fisher/first_principles_tully_fisher.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a80f850226d7a536fad6f33fdae2d08bee9bf36c3a28c452ed0aaa244c88bf39
+size 423


### PR DESCRIPTION
Data comes from two symbolic regression repos:
- Miles Cranmer's PySR: https://github.com/MilesCranmer/PySR
- Etienne Russeil et al.'s MvSR: https://github.com/erusseil/MvSR-analysis

They are all datasets that have a first-principle equation derived from data and used in their respective papers to show how symbolic regression has the potential of retrieving the original equation when only observational data is available.

While some of them have just a few samples and  others are synthetically generated, they are challenging for symbolic regression methods and can be used to evaluate these algorithms.

The idea of pushing them into PMLB is to help other users to quickly set up experiments with the data.

I still need to write proper metadata for them.