### PR TITLE
Rethinking Feynman datasets

### DIFF
--- a/datasets/rethinking_feynman-i_30_3/rethinking_feynman-i_30_3.tsv.gz
+++ b/datasets/rethinking_feynman-i_30_3/rethinking_feynman-i_30_3.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08a93a1c326b69bfb5ce9a8452fbcde39a853db6bbb2a5451892a59017332af4
+size 303085

--- a/datasets/rethinking_feynman-i_32_17/rethinking_feynman-i_32_17.tsv.gz
+++ b/datasets/rethinking_feynman-i_32_17/rethinking_feynman-i_32_17.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4f3e93a88561216b0f63c9c04a458c09f6a29472f65d9c6a3d4657a79858710
+size 467884

--- a/datasets/rethinking_feynman-i_40_1/rethinking_feynman-i_40_1.tsv.gz
+++ b/datasets/rethinking_feynman-i_40_1/rethinking_feynman-i_40_1.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0bc1d81bf5f3264b038c715c35e3b9392577a51eea62ac7fd00e526ced1b6bd
+size 476685

--- a/datasets/rethinking_feynman-i_44_4/rethinking_feynman-i_44_4.tsv.gz
+++ b/datasets/rethinking_feynman-i_44_4/rethinking_feynman-i_44_4.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5eb115227f852c1a324e600e2d0f10a54a14eca914242bc1d8f565d4fe38fcba
+size 477051

--- a/datasets/rethinking_feynman-ii_11_20/rethinking_feynman-ii_11_20.tsv.gz
+++ b/datasets/rethinking_feynman-ii_11_20/rethinking_feynman-ii_11_20.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c49df2b67b167a5e191e7a958e309379a75b2f26801ff9e605ac13c4faf29d17
+size 481573

--- a/datasets/rethinking_feynman-ii_11_27/rethinking_feynman-ii_11_27.tsv.gz
+++ b/datasets/rethinking_feynman-ii_11_27/rethinking_feynman-ii_11_27.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6f9588a001895881b2cb41d9f57082f730a7e5b7fb505e4b274caf76825643e
+size 384322

--- a/datasets/rethinking_feynman-ii_35_21/rethinking_feynman-ii_35_21.tsv.gz
+++ b/datasets/rethinking_feynman-ii_35_21/rethinking_feynman-ii_35_21.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7c0c20f6141e7461582bf7c3c0f69e827e39361af0615ee53dfde1a6d83ed07
+size 478764

--- a/datasets/rethinking_feynman-ii_36_38/rethinking_feynman-ii_36_38.tsv.gz
+++ b/datasets/rethinking_feynman-ii_36_38/rethinking_feynman-ii_36_38.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:305190677bb2615b11364716145743ca2d61c55961c28738fcb63acf68362689
+size 575481

--- a/datasets/rethinking_feynman-ii_6_15b/rethinking_feynman-ii_6_15b.tsv.gz
+++ b/datasets/rethinking_feynman-ii_6_15b/rethinking_feynman-ii_6_15b.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4662d95cc11ec32f08184b59824a18c3bf51b7269a434d2c49e175830bd382f6
+size 383447

--- a/datasets/rethinking_feynman-iii_10_19/rethinking_feynman-iii_10_19.tsv.gz
+++ b/datasets/rethinking_feynman-iii_10_19/rethinking_feynman-iii_10_19.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ddd613006ff4b84d82232c51ee455486a285bf3094dec17909576de55ef93b3
+size 477603

--- a/datasets/rethinking_feynman-iii_21_20/rethinking_feynman-iii_21_20.tsv.gz
+++ b/datasets/rethinking_feynman-iii_21_20/rethinking_feynman-iii_21_20.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65b489009c9c48318591bb90425199da2d3bfa1944287bdc8616a366e3f12f85
+size 484504

--- a/datasets/rethinking_feynman-iii_9_52/rethinking_feynman-iii_9_52.tsv.gz
+++ b/datasets/rethinking_feynman-iii_9_52/rethinking_feynman-iii_9_52.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0b424b744be11955f40c5a2f24101eb81a667a6f003e96327a2591afc902185
+size 575740


### PR DESCRIPTION
[Matsubara et al.](https://arxiv.org/abs/2206.10540) did an amazing job rethinking the entire Feynman benchmark, proposing different ways of sampling the features when generating synthetic data and using fewer samples.

As a first initial attempt to integrate their contributions in PMLB, I am publishing my data-generated datasets based
[on their scripts](https://github.com/omron-sinicx/srsd-benchmark/tree/main) but using only uniform distribution (instead of the proposed log loss distribution).

To avoid conflicts with the existing Feynman datasets, I am naming them as `rethinking_feynman`.

Data is already in the PMLB standards.